### PR TITLE
Feat: Added constant generator

### DIFF
--- a/generators/constant.go
+++ b/generators/constant.go
@@ -1,0 +1,19 @@
+package generators
+
+import (
+	"github.com/bspaans/bleep/audio"
+)
+
+// NewConstantOscillator creates generator with always constant value in sample out.
+// You can use it as input for constant pitch, gain, etc. for setting dynamic parameters in other generators.
+func NewConstantOscillator(value float64) Generator {
+	g := NewBaseGenerator()
+	g.GetSamplesFunc = func(cfg *audio.AudioConfig, n int) []float64 {
+		result := GetEmptySampleArray(cfg, n)
+		for i := range result {
+			result[i] = value
+		}
+		return result
+	}
+	return g
+}


### PR DESCRIPTION
Hope this can use for setting constant values.

Here is my idea:

Generators has a few values like pitch, gain, phase, etc. which can be setted by sort of LFO generator (any generator from which real generator take value data)

Honestly, i don't know, does this package used by anyone, so i don't want to break current architecture. Thanks this, i want a tip grom you, @bspaans, am i need to implement this idea in `AdvancedGenerator` struct or sort of?